### PR TITLE
Fixed QSTile not working after another VPN service was used

### DIFF
--- a/app/src/main/java/com/cherret/zaprett/utils/QSTileService.kt
+++ b/app/src/main/java/com/cherret/zaprett/utils/QSTileService.kt
@@ -2,6 +2,7 @@ package com.cherret.zaprett.utils
 
 import android.content.Intent
 import android.content.SharedPreferences
+import android.net.VpnService
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import androidx.core.content.ContextCompat
@@ -36,7 +37,12 @@ class QSTileService: TileService() {
                 startService {}
             }
             else {
-                ContextCompat.startForegroundService(applicationContext, Intent(applicationContext, ByeDpiVpnService::class.java).apply { action = "START_VPN" })
+                val prepareIntent = VpnService.prepare(applicationContext)
+                if (prepareIntent != null) {
+                    startActivityAndCollapse(prepareIntent)
+                } else {
+                    ContextCompat.startForegroundService(applicationContext, Intent(applicationContext, ByeDpiVpnService::class.java).apply { action = "START_VPN" })
+                }
             }
         }
         else {


### PR DESCRIPTION
Фикс для иконки из верхнего выпадающего меню: если включить и выключить любой другой VPN сервис, после чего попытаться включить zaprett через эту иконку - уведомление покажет, что сервис включен, в приложении будет написано, что сервис включен, но работать он не будет.

Баг проверял только у себя на One UI 8.0, но судя по его природе полагаю что проблема должна быть глобальная.

В этом ПРе предлагаю самый тупой фикс который удалось скрафтить - можно сделать хорошо, но об этом я предлагаю уже задуматься авторам :)